### PR TITLE
Fix MessageBox parameter name

### DIFF
--- a/user32.go
+++ b/user32.go
@@ -570,10 +570,10 @@ func GetWindowThreadProcessId(hwnd HWND) (HANDLE, int) {
 	return HANDLE(ret), processId
 }
 
-func MessageBox(hwnd HWND, title, caption string, flags uint) int {
+func MessageBox(hwnd HWND, text, caption string, flags uint) int {
 	ret, _, _ := procMessageBox.Call(
 		uintptr(hwnd),
-		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(title))),
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(text))),
 		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(caption))),
 		uintptr(flags))
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-messagebox

The second parameter is the content (text), not the title, the third (caption) means the title.